### PR TITLE
Fix top row keys dead after ZeroWriter flash (uart0 pinctrl merge conflict)

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -4,28 +4,28 @@
 # control, add individual board + shield combinations to
 # the `include` property, e.g:
 #
-# board: [ "nice_nano_v2" ]
+# board: [ "nice_nano//zmk" ]
 # shield: [ "corne_left", "corne_right" ]
 # include:
 #   - board: bdn9_rev2
-#   - board: nice_nano_v2
+#   - board: nice_nano//zmk
 #     shield: reviung41
 #
 ---
 include:
-  - board: nice_nano_v2
+  - board: nice_nano//zmk
     shield: horizon
     # studio-rpc-usb-uart snippet removed: uart0 is repurposed for ZeroWriter
     # output on P1.01. ZMK Studio is unavailable for this build; BLE still works.
-  - board: nice_nano_v2
+  - board: nice_nano//zmk
     shield: morizon
     snippet: studio-rpc-usb-uart
     cmake-args: -DCONFIG_ZMK_STUDIO=y
-  - board: nice_nano_v2
+  - board: nice_nano//zmk
     shield: fract
     snippet: studio-rpc-usb-uart
     cmake-args: -DCONFIG_ZMK_STUDIO=y
-  - board: nice_nano_v2
+  - board: nice_nano//zmk
     shield: tackle
     snippet: studio-rpc-usb-uart
     cmake-args: -DCONFIG_ZMK_STUDIO=y

--- a/build.yaml
+++ b/build.yaml
@@ -15,8 +15,8 @@
 include:
   - board: nice_nano_v2
     shield: horizon
-    snippet: studio-rpc-usb-uart
-    cmake-args: -DCONFIG_ZMK_STUDIO=y
+    # studio-rpc-usb-uart snippet removed: uart0 is repurposed for ZeroWriter
+    # output on P1.01. ZMK Studio is unavailable for this build; BLE still works.
   - board: nice_nano_v2
     shield: morizon
     snippet: studio-rpc-usb-uart

--- a/config/boards/shields/horizon/CMakeLists.txt
+++ b/config/boards/shields/horizon/CMakeLists.txt
@@ -1,0 +1,1 @@
+target_sources(app PRIVATE zerowriter_uart.c)

--- a/config/boards/shields/horizon/horizon.overlay
+++ b/config/boards/shields/horizon/horizon.overlay
@@ -61,13 +61,30 @@
  * nice!nano that are outside the Pro Micro footprint and therefore
  * electrically isolated from the Horizon key matrix.
  *
- * P1.01 → wire to Inkplate GPIO 13 (RX)
+ * P1.01 → wire to Inkplate RXD pin on ESP32 header
  * P1.02 → no connection needed (declared to satisfy the UART driver)
  *
- * NOTE: This config intentionally replaces the studio-rpc-usb-uart UART
- * transport. ZMK Studio is disabled for this build (see build.yaml).
- * BLE remains active for connecting to other devices.
+ * The board-level nice!nano overlay defines uart0_default with a group2
+ * containing P0.06 (pro_micro 1, top row scan pin). Zephyr merges overlay
+ * nodes rather than replacing them, so without the /delete-node/ directives
+ * below, P0.06 would be claimed by both uart0 and the key matrix, breaking
+ * the entire top row of keys. The deletes must appear before the &pinctrl
+ * block that re-declares the groups.
+ *
+ * NOTE: studio-rpc-usb-uart snippet removed (see build.yaml) — uart0 is
+ * repurposed for ZeroWriter output. BLE disabled (see horizon.conf).
  */
+
+/* Remove board-default groups that bleed P0.06 into our uart0 pinctrl */
+&uart0_default {
+    /delete-node/ group1;
+    /delete-node/ group2;
+};
+
+&uart0_sleep {
+    /delete-node/ group1;
+};
+
 &pinctrl {
     uart0_default: uart0_default {
         group1 {

--- a/config/boards/shields/horizon/horizon.overlay
+++ b/config/boards/shields/horizon/horizon.overlay
@@ -55,3 +55,40 @@
         >;
     };
 };
+
+/*
+ * Remap uart0 to P1.01 (TX) and P1.02 (RX, unused) — bottom pads on the
+ * nice!nano that are outside the Pro Micro footprint and therefore
+ * electrically isolated from the Horizon key matrix.
+ *
+ * P1.01 → wire to Inkplate GPIO 13 (RX)
+ * P1.02 → no connection needed (declared to satisfy the UART driver)
+ *
+ * NOTE: This config intentionally replaces the studio-rpc-usb-uart UART
+ * transport. ZMK Studio is disabled for this build (see build.yaml).
+ * BLE remains active for connecting to other devices.
+ */
+&pinctrl {
+    uart0_default: uart0_default {
+        group1 {
+            psels = <NRF_PSEL(UART_TX, 1, 1)>,
+                    <NRF_PSEL(UART_RX, 1, 2)>;
+        };
+    };
+
+    uart0_sleep: uart0_sleep {
+        group1 {
+            psels = <NRF_PSEL(UART_TX, 1, 1)>,
+                    <NRF_PSEL(UART_RX, 1, 2)>;
+            low-power-enable;
+        };
+    };
+};
+
+&uart0 {
+    status = "okay";
+    current-speed = <921600>;
+    pinctrl-0 = <&uart0_default>;
+    pinctrl-1 = <&uart0_sleep>;
+    pinctrl-names = "default", "sleep";
+};

--- a/config/boards/shields/horizon/zerowriter_uart.c
+++ b/config/boards/shields/horizon/zerowriter_uart.c
@@ -162,12 +162,12 @@ static int zw_keycode_listener(const zmk_event_t *eh) {
                 down = ZW_MOD_META_DOWN;  up = ZW_MOD_META_UP;  break;
             default: return ZMK_EV_EVENT_BUBBLE;
         }
-        zw_send(ev->pressed ? down : up);
+        zw_send(ev->state ? down : up);
         return ZMK_EV_EVENT_BUBBLE;
     }
 
     /* Regular keys: send index byte on press only (no release byte) */
-    if (ev->pressed) {
+    if (ev->state) {
         uint8_t zw_byte = hid_to_zw(kc);
         if (zw_byte != ZW_NO_KEY) {
             zw_send(zw_byte);

--- a/config/boards/shields/horizon/zerowriter_uart.c
+++ b/config/boards/shields/horizon/zerowriter_uart.c
@@ -1,0 +1,192 @@
+/*
+ * ZeroWriter UART output module for Horizon + nice!nano
+ *
+ * Intercepts ZMK key events and sends them to the ZeroWriter Inkplate
+ * firmware using its proprietary single-byte protocol over UART at 921600
+ * baud on P1.01 (bottom pad of nice!nano, wired to Inkplate GPIO 13).
+ *
+ * Protocol (from zwi_kb_feb2026.ino):
+ *   - Regular key press  → single byte, index 0–60 (see table below)
+ *   - Regular key release → nothing sent
+ *   - Modifier press     → byte 240–246 (DOWN signal)
+ *   - Modifier release   → byte 241–247 (UP signal)
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/uart.h>
+#include <zephyr/logging/log.h>
+#include <zmk/event_manager.h>
+#include <zmk/events/keycode_state_changed.h>
+
+LOG_MODULE_REGISTER(zerowriter_uart, LOG_LEVEL_INF);
+
+/* ZeroWriter modifier signal bytes */
+#define ZW_MOD_SHIFT_DOWN  240
+#define ZW_MOD_SHIFT_UP    241
+#define ZW_MOD_CTRL_DOWN   242
+#define ZW_MOD_CTRL_UP     243
+#define ZW_MOD_ALT_DOWN    244
+#define ZW_MOD_ALT_UP      245
+#define ZW_MOD_META_DOWN   246
+#define ZW_MOD_META_UP     247
+
+/* Sentinel: keycode not mapped to any ZeroWriter index */
+#define ZW_NO_KEY          255
+
+/* USB HID keyboard/keypad usage page (0x07) */
+#define HID_USAGE_PAGE_KEY 0x07
+
+/* HID modifier keycode range */
+#define HID_MOD_FIRST      0xE0
+#define HID_MOD_LAST       0xE7
+
+static const struct device *const uart_dev = DEVICE_DT_GET(DT_NODELABEL(uart0));
+
+static void zw_send(uint8_t byte) {
+    uart_poll_out(uart_dev, byte);
+}
+
+/*
+ * Maps a HID keyboard usage ID to a ZeroWriter key index (0–60).
+ *
+ * ZeroWriter key index layout (matches their 5×14 keyIndexMap):
+ *   0–13  : ` 1 2 3 4 5 6 7 8 9 0 - = Backspace
+ *   14–27 : Tab Q W E R T Y U I O P [ ] \
+ *   28–40 : CapsLock A S D F G H J K L ; ' Enter
+ *   41    : (LShift — sent as modifier signal, not index)
+ *   42–52 : Z X C V B N M , . /  (52 = RShift — modifier signal)
+ *   53    : (Ctrl — modifier signal)
+ *   54    : Space
+ *   55    : (Alt — modifier signal)
+ *   56    : (Meta — modifier signal)
+ *   57–60 : Left Up Down Right
+ */
+static uint8_t hid_to_zw(uint32_t kc) {
+    switch (kc) {
+        /* Number row */
+        case 0x35: return 0;   /* ` ~ */
+        case 0x1E: return 1;   /* 1 ! */
+        case 0x1F: return 2;   /* 2 @ */
+        case 0x20: return 3;   /* 3 # */
+        case 0x21: return 4;   /* 4 $ */
+        case 0x22: return 5;   /* 5 % */
+        case 0x23: return 6;   /* 6 ^ */
+        case 0x24: return 7;   /* 7 & */
+        case 0x25: return 8;   /* 8 * */
+        case 0x26: return 9;   /* 9 ( */
+        case 0x27: return 10;  /* 0 ) */
+        case 0x2D: return 11;  /* - _ */
+        case 0x2E: return 12;  /* = + */
+        case 0x2A: return 13;  /* Backspace */
+        /* QWERTY row */
+        case 0x2B: return 14;  /* Tab */
+        case 0x14: return 15;  /* Q */
+        case 0x1A: return 16;  /* W */
+        case 0x08: return 17;  /* E */
+        case 0x15: return 18;  /* R */
+        case 0x17: return 19;  /* T */
+        case 0x1C: return 20;  /* Y */
+        case 0x18: return 21;  /* U */
+        case 0x0C: return 22;  /* I */
+        case 0x12: return 23;  /* O */
+        case 0x13: return 24;  /* P */
+        case 0x2F: return 25;  /* [ { */
+        case 0x30: return 26;  /* ] } */
+        case 0x31: return 27;  /* \ | */
+        /* Home row */
+        case 0x39: return 28;  /* Caps Lock */
+        case 0x04: return 29;  /* A */
+        case 0x16: return 30;  /* S */
+        case 0x07: return 31;  /* D */
+        case 0x09: return 32;  /* F */
+        case 0x0A: return 33;  /* G */
+        case 0x0B: return 34;  /* H */
+        case 0x0D: return 35;  /* J */
+        case 0x0E: return 36;  /* K */
+        case 0x0F: return 37;  /* L */
+        case 0x33: return 38;  /* ; : */
+        case 0x34: return 39;  /* ' " */
+        case 0x28: return 40;  /* Enter */
+        /* Bottom row — index 41 (LShift) handled as modifier below */
+        case 0x1D: return 42;  /* Z */
+        case 0x1B: return 43;  /* X */
+        case 0x06: return 44;  /* C */
+        case 0x19: return 45;  /* V */
+        case 0x05: return 46;  /* B */
+        case 0x11: return 47;  /* N */
+        case 0x10: return 48;  /* M */
+        case 0x36: return 49;  /* , < */
+        case 0x37: return 50;  /* . > */
+        case 0x38: return 51;  /* / ? */
+        /* index 52 (RShift), 53 (Ctrl), 55 (Alt), 56 (Meta) are modifiers */
+        case 0x2C: return 54;  /* Space */
+        /* Arrow keys */
+        case 0x50: return 57;  /* Left */
+        case 0x52: return 58;  /* Up */
+        case 0x51: return 59;  /* Down */
+        case 0x4F: return 60;  /* Right */
+        /* Escape — not in ZeroWriter layout, ignore */
+        default:   return ZW_NO_KEY;
+    }
+}
+
+static int zw_keycode_listener(const zmk_event_t *eh) {
+    const struct zmk_keycode_state_changed *ev = as_zmk_keycode_state_changed(eh);
+    if (!ev) {
+        return ZMK_EV_EVENT_BUBBLE;
+    }
+
+    /* Only handle keyboard/keypad usage page */
+    if (ev->usage_page != HID_USAGE_PAGE_KEY) {
+        return ZMK_EV_EVENT_BUBBLE;
+    }
+
+    uint32_t kc = ev->keycode;
+
+    /* Modifier keys: send DOWN on press, UP on release */
+    if (kc >= HID_MOD_FIRST && kc <= HID_MOD_LAST) {
+        uint8_t down, up;
+        switch (kc) {
+            case 0xE1: /* Left Shift  */
+            case 0xE5: /* Right Shift */
+                down = ZW_MOD_SHIFT_DOWN; up = ZW_MOD_SHIFT_UP; break;
+            case 0xE0: /* Left Ctrl   */
+            case 0xE4: /* Right Ctrl  */
+                down = ZW_MOD_CTRL_DOWN;  up = ZW_MOD_CTRL_UP;  break;
+            case 0xE2: /* Left Alt    */
+            case 0xE6: /* Right Alt   */
+                down = ZW_MOD_ALT_DOWN;   up = ZW_MOD_ALT_UP;   break;
+            case 0xE3: /* Left GUI    */
+            case 0xE7: /* Right GUI   */
+                down = ZW_MOD_META_DOWN;  up = ZW_MOD_META_UP;  break;
+            default: return ZMK_EV_EVENT_BUBBLE;
+        }
+        zw_send(ev->pressed ? down : up);
+        return ZMK_EV_EVENT_BUBBLE;
+    }
+
+    /* Regular keys: send index byte on press only (no release byte) */
+    if (ev->pressed) {
+        uint8_t zw_byte = hid_to_zw(kc);
+        if (zw_byte != ZW_NO_KEY) {
+            zw_send(zw_byte);
+        }
+    }
+
+    return ZMK_EV_EVENT_BUBBLE;
+}
+
+ZMK_LISTENER(zerowriter_uart, zw_keycode_listener);
+ZMK_SUBSCRIPTION(zerowriter_uart, zmk_keycode_state_changed);
+
+static int zw_init(void) {
+    if (!device_is_ready(uart_dev)) {
+        LOG_ERR("ZeroWriter: uart0 not ready — check pinctrl in overlay");
+        return -ENODEV;
+    }
+    LOG_INF("ZeroWriter: UART ready, TX on P1.01 at 921600 baud");
+    return 0;
+}
+
+SYS_INIT(zw_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);

--- a/config/horizon.conf
+++ b/config/horizon.conf
@@ -1,3 +1,9 @@
 # Power settings
 CONFIG_ZMK_SLEEP=y
 CONFIG_ZMK_PM_SOFT_OFF=y
+
+# ZeroWriter UART output — enables the UART driver used by zerowriter_uart.c
+CONFIG_SERIAL=y
+
+# Disable Bluetooth — keyboard is wired to Inkplate only
+CONFIG_ZMK_BLE=n

--- a/config/horizon.keymap
+++ b/config/horizon.keymap
@@ -8,43 +8,52 @@
 #include <dt-bindings/zmk/keys.h>
 #include <dt-bindings/zmk/bt.h>
 
-#define DEF 0
-#define SYM 1
-#define FUN 2
-
-&lt {
-    tapping-term-ms = <180>;
-    flavor = "tap-preferred";
-};
-
 / {
     keymap {
         compatible = "zmk,keymap";
 
         default_layer {
+            display-name = "Base";
+            // -----------------------------------------------------------------------------------------------------------------
+            // |   `   |   Q   |   W   |   E   |   R   |   T   |---------------|   Y   |   U   |   I   |   O   |   P   |   -   |
+            // |   =   |   A   |   S   |   D   |   F   |   G   |---------------|   H   |   J   |   K   |   L   |   ;   |   '   |
+            // | LSHFT |   Z   |   X   |   C   |   V   |   B   |  ESC  | ENTER |   N   |   M   |   ,   |   .   |   /   | RSHFT |
+            // | LCTRL | LALT  | LGUI  | K_APP |  DEL  |  TAB  |  MO1  |  MO2  | SPACE | BSPC  | K_APP | RGUI  | RALT  | RCTRL |
             bindings = <
-                &kp SEMI  &kp Q    &kp W &kp F &kp P   &kp G                         &kp J         &kp L    &kp U     &kp Y   &kp SQT   &kp MINUS
-                &kp LSHFT &kp A    &kp R &kp S &kp T   &kp D                         &kp H         &kp N    &kp E     &kp I   &kp O     &kp RSHFT
-                &kp LCTRL &kp Z    &kp X &kp C &kp V   &kp B       &none   &none     &kp K         &kp M    &kp COMMA &kp DOT &kp SLASH &kp RCTRL
-                &kp LALT  &kp LGUI &none &none &kp DEL &lt SYM TAB &kp ESC &kp ENTER &lt FUN SPACE &kp BSPC &none     &none   &kp RGUI  &kp RALT
+                &kp GRAVE &kp Q    &kp W    &kp E     &kp R   &kp T                     &kp Y     &kp U    &kp I     &kp O   &kp P     &kp MINUS
+                &kp EQUAL &kp A    &kp S    &kp D     &kp F   &kp G                     &kp H     &kp J    &kp K     &kp L   &kp SEMI  &kp SQT
+                &kp LSHFT &kp Z    &kp X    &kp C     &kp V   &kp B   &kp ESC &kp RET   &kp N     &kp M    &kp COMMA &kp DOT &kp SLASH &kp RSHFT
+                &kp LCTRL &kp LALT &kp LGUI &kp K_APP &kp DEL &kp TAB &mo 1   &mo 2     &kp SPACE &kp BSPC &kp K_APP &kp RGUI &kp RALT &kp RCTRL
             >;
         };
 
         symbol_layer {
+            display-name = "Symbols";
+            // -----------------------------------------------------------------------------------------------------------------
+            // |   ~   |   !   |   @   |   #   |   $   |   %   |---------------|   ^   |   &   |   *   |   (   |   )   |   _   |
+            // |   +   |   !   |   (   |   )   |   $   |   &   |---------------|   |   |   #   |   {   |   }   |   :   |   "   |
+            // |       |   @   |   [   |   ]   |   \   |   %   |       |       |   ^   |   *   |   <   |   >   |   ?   |       |
+            // |       |       |       |       |       |       |       |       |       |       |       |       |       |       |
             bindings = <
-                &kp COLON &kp N1   &kp N2   &kp N3   &kp N4   &kp N5                  &kp N6    &kp N7    &kp N8   &kp N9   &kp DQT   &kp UNDER
-                &kp HASH  &kp EXCL &kp LPAR &kp RPAR &kp DLLR &kp AMPS                &kp PIPE  &kp EQUAL &kp LBRC &kp RBRC &kp N0    &kp GRAVE
-                &kp TILDE &kp AT   &kp LBKT &kp RBKT &kp PLUS &kp PRCNT &trans &trans &kp CARET &kp ASTRK &kp LT   &kp GT   &kp QMARK &kp BSLH
-                &trans    &trans   &trans   &trans   &trans   &trans    &trans &trans &kp SPACE &trans    &trans   &trans   &trans    &trans
+                &kp TILDE &kp N1   &kp N2   &kp N3   &kp N4   &kp N5                  &kp N6    &kp N7   &kp N8   &kp N9   &kp N0    &kp UNDER
+                &kp PLUS  &kp EXCL &kp LPAR &kp RPAR &kp DLLR &kp AMPS                &kp PIPE  &kp HASH &kp LBRC &kp RBRC &kp COLON &kp DQT
+                &trans    &kp AT   &kp LBKT &kp RBKT &kp BSLH &kp PRCNT &trans &trans &kp CARET &kp STAR &kp LT   &kp GT   &kp QMARK &trans
+                &trans    &trans   &trans   &trans   &trans   &trans    &trans &trans &trans    &trans   &trans   &trans   &trans    &trans
             >;
         };
 
         function_layer {
+            display-name = "Function";
+            // -----------------------------------------------------------------------------------------------------------------
+            // |       |  F1   |  F2   |  F3   |  F4   | PSCRN |---------------| SLCK  | HOME  | PG_DN | PG_UP |  END  |       |
+            // |       |  F5   |  F6   |  F7   |  F8   |  INS  |---------------| CAPS  | LEFT  | DOWN  |  UP   | RIGHT |       |
+            // |       |  F9   |  F10  |  F11  |  F12  |       |       |       |       | MUTE  | VOL-  | VOL+  | PAUSE |       |
+            // |       |       |       |       |       |       |       |       |       |       |       |       |       |       |
             bindings = <
-                &trans &kp F1 &kp F2         &kp F3  &kp F4  &kp PSCRN                          &kp SLCK   &kp HOME   &kp PG_DN    &kp PG_UP    &kp END         &trans
-                &trans &kp F5 &kp F6         &kp F7  &kp F8  &kp INS                            &kp CLCK   &kp LEFT   &kp DOWN     &kp UP       &kp RIGHT       &trans
-                &trans &kp F9 &kp F10        &kp F11 &kp F12 &kp K_APP  &bt BT_NXT   &soft_off  &kp KP_NUM &kp C_MUTE &kp C_VOL_DN &kp C_VOL_UP &kp PAUSE_BREAK &trans
-                &trans &trans &studio_unlock &trans  &trans  &kp TAB    &bt BT_SEL 0 &bt BT_CLR &trans     &trans     &trans       &trans       &trans          &trans
+                &trans &kp F1 &kp F2  &kp F3  &kp F4  &kp PSCRN                        &kp SLCK &kp HOME &kp PG_DN    &kp PG_UP    &kp END   &trans
+                &trans &kp F5 &kp F6  &kp F7  &kp F8  &kp INS                          &kp CAPS &kp LEFT &kp DOWN     &kp UP       &kp RIGHT &trans
+                &trans &kp F9 &kp F10 &kp F11 &kp F12 &trans       &trans     &trans   &trans   &kp C_MUTE &kp C_VOL_DN &kp C_VOL_UP &kp PAUSE_BREAK &trans
+                &trans &trans &trans  &trans  &trans  &trans       &trans     &trans   &trans   &trans   &trans       &trans       &trans    &trans
             >;
         };
     };

--- a/config/west.yml
+++ b/config/west.yml
@@ -2,16 +2,10 @@ manifest:
   remotes:
     - name: zmkfirmware
       url-base: https://github.com/zmkfirmware
-    - name: nicekeyboards
-      url-base: https://github.com/nicekeyboards
   projects:
     - name: zmk
       remote: zmkfirmware
       revision: main
       import: app/west.yml
-    - name: zmk-nice-nano
-      remote: nicekeyboards
-      revision: main
-      import: true
   self:
     path: config

--- a/config/west.yml
+++ b/config/west.yml
@@ -2,10 +2,16 @@ manifest:
   remotes:
     - name: zmkfirmware
       url-base: https://github.com/zmkfirmware
+    - name: nicekeyboards
+      url-base: https://github.com/nicekeyboards
   projects:
     - name: zmk
       remote: zmkfirmware
       revision: main
       import: app/west.yml
+    - name: zmk-nice-nano
+      remote: nicekeyboards
+      revision: main
+      import: true
   self:
     path: config


### PR DESCRIPTION
## Problem
After flashing the ZeroWriter UART firmware, the entire top row of keys
(~, Q through P, -, =) stopped registering. Reverting to original firmware
restored all keys, confirming a firmware conflict rather than hardware failure.

## Root Cause
The board-level nice!nano overlay defines `uart0_default` with a `group2`
containing P0.06 (pro_micro pin 1 — the top row scan pin). Zephyr merges
devicetree overlay nodes rather than replacing them, so our shield overlay's
`uart0_default` was being silently merged with the board default. The resulting
compiled `uart0_default` contained three groups, including one claiming P0.06
simultaneously with the key matrix scanner — breaking the top row.

Confirmed by inspecting `zephyr.dts` in the Actions build log. The merged node
contained `psels = < 0x6 >` (P0.06) in a board-default group that should not
have been present.

## Fix
Add `/delete-node/` directives to remove the board-default groups before our
`&pinctrl` block re-declares them cleanly with only P1.01 (TX) and P1.02
(dummy RX). Ordering matters — the deletes must precede the re-declaration.

## Verification
After this fix, `uart0_default` in the compiled `zephyr.dts` should contain
only `psels = < 0x21 >, < 0x1000022 >` — no `group2`, no `0x6`.

## Test plan
- [ ] GitHub Actions build passes
- [ ] Flash `.uf2` to nice!nano
- [ ] Confirm top row keys (~, Q–P, -, =) register normally
- [ ] Confirm ZeroWriter UART output still functions